### PR TITLE
DM-31364: Add Patch Thursday messages for IDF

### DIFF
--- a/broadcasts/101_idfprod_pre_patch_thursday.md
+++ b/broadcasts/101_idfprod_pre_patch_thursday.md
@@ -1,0 +1,25 @@
+---
+enabled: true
+summary: [Patch Thursday](https://community.lsst.org/t/what-is-rsp-patch-thursday/5647) is **today**, 3pm–5pm Pacific / 22:00–00:00 UT.
+env:
+  - idfdev
+  - idfint
+  - idfprod
+timezone: America/Los Angeles
+ttl: 3hr
+rules:
+  - freq: weekly
+    start: 2021-08-11T12:00
+    by_weekday:
+      - day: thursday
+---
+
+On most Thursday afternoons we deploy updates and perform routine maintenance actions on the Rubin Science Platform.
+
+This is not a outage period and you do not need to stop using the Platform.
+
+However there might be transient service interruptions or instabilities during this time, and very rarely an update can take longer than anticipated because of issues not seen in testing.
+**If you are using the RSP during this time, save your work early and often** as on rare occasions user sessions may need to be terminated.
+Wait until after this window to [file bug reports](https://data.lsst.cloud/support) (if you still see a problem).
+
+For more information about Patch Thursday, [see our post on the Community forum](https://community.lsst.org/t/what-is-rsp-patch-thursday/5647).

--- a/broadcasts/102_idfprod_patch_thursday.md
+++ b/broadcasts/102_idfprod_patch_thursday.md
@@ -1,0 +1,25 @@
+---
+enabled: true
+summary: [Patch Thursday](https://community.lsst.org/t/what-is-rsp-patch-thursday/5647) is **happening now,** 3pm–5pm Pacific / 22:00–00:00 UT.
+env:
+  - idfdev
+  - idfint
+  - idfprod
+timezone: America/Los Angeles
+ttl: 2hr
+rules:
+  - freq: weekly
+    start: 2021-08-11T15:00
+    by_weekday:
+      - day: thursday
+---
+
+On most Thursday afternoons we deploy updates and perform routine maintenance actions on the Rubin Science Platform.
+
+This is not a outage period and you do not need to stop using the Platform.
+
+However there might be transient service interruptions or instabilities during this time, and very rarely an update can take longer than anticipated because of issues not seen in testing.
+**If you are using the RSP during this time, save your work early and often** as on rare occasions user sessions may need to be terminated.
+Wait until after this window to [file bug reports](https://data.lsst.cloud/support) (if you still see a problem).
+
+For more information about Patch Thursday, [see our post on the Community forum](https://community.lsst.org/t/what-is-rsp-patch-thursday/5647).

--- a/broadcasts/103_idfprod_idfprod_patch_thursday_extended.md
+++ b/broadcasts/103_idfprod_idfprod_patch_thursday_extended.md
@@ -1,0 +1,18 @@
+---
+enabled: false
+summary: [Patch Thursday](https://community.lsst.org/t/what-is-rsp-patch-thursday/5647) is still ongoing.
+env:
+  - idfdev
+  - idfint
+  - idfprod
+---
+
+On most Thursday afternoons we deploy updates and perform routine maintenance actions on the Rubin Science Platform.
+
+This is not a outage period and you do not need to stop using the Platform.
+
+However there might be transient service interruptions or instabilities during this time, and very rarely an update can take longer than anticipated because of issues not seen in testing.
+**If you are using the RSP during this time, save your work early and often** as on rare occasions user sessions may need to be terminated.
+Wait until after this window to [file bug reports](https://data.lsst.cloud/support) (if you still see a problem).
+
+For more information about Patch Thursday, [see our post on the Community forum](https://community.lsst.org/t/what-is-rsp-patch-thursday/5647).


### PR DESCRIPTION
The `pre_patch_thursday` and `patch_thursday` messages have a recurring schedule, so they should trigger automatically.

The patch_thursday_extended message can be manually enabled to show a special patch thursday message after the window has elapsed to tell folks that we're still doing work.