### PR TITLE
Reactivate patch thursday message (on timer)

### DIFF
--- a/broadcasts/102_idfprod_patch_thursday.md
+++ b/broadcasts/102_idfprod_patch_thursday.md
@@ -1,5 +1,5 @@
 ---
-enabled: false
+enabled: true
 summary: |
   [Patch Thursday](https://community.lsst.org/t/what-is-rsp-patch-thursday/5647) is **happening now,** 3pm–5pm Pacific / 22:00–00:00 UT.
 env:


### PR DESCRIPTION
This was disabled at the end of the previous patch thursday, and now should be re-enabled to make it automatically appear for today's patches.