### PR TITLE
Add Sasquatch news feed

### DIFF
--- a/jsonfeeds/README.md
+++ b/jsonfeeds/README.md
@@ -1,0 +1,28 @@
+# Sasquatch news feed
+
+Chronograf is the main UI for the [Sasquatch](https://sqr-068.lsst.io) RSP service.
+
+Chronograf uses the [JSON Feed Version 1.1](https://www.jsonfeed.org) specification to display a news feed on the client Status page.
+
+This folder contains the JSON feed files used in each of the RSP environments where we deploy Sasquatch.
+These files are served from the main branch of this repository, for example this is the URL for the [tucson_teststand.json](https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/tucson-teststand.json) feed.
+
+To add a new item to the JSON feed, edit the file for the corresponding RSP environment and add the following content under the `items` key.
+Remember to increment the item `id` number.
+
+```
+{
+    "id": "12",
+    "url": "https://sqr-068.lsst.io",
+    "title": "Long live Sasquatch!",
+    "content_text": "Sasquatch is a new service of the RSP that hosts the EFD, learn more at SQR-068.",
+    "date_published": "2022-07-11T02:00:00-07:00",
+    "date_modified": "2022-07-11T02:00:00-07:00",
+    "image": "",
+    "authors": [
+        {
+            "name": "SQuaRE"
+        }
+    ]
+},
+```

--- a/jsonfeeds/base.json
+++ b/jsonfeeds/base.json
@@ -1,0 +1,107 @@
+{
+    "version": "https://jsonfeed.org/version/1.1",
+    "user_comment": "Sasquatch news feed.",
+    "home_page_url": "http://chronograf-base-efd.lsst.codes",
+    "feed_url": "https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeed/base.json",
+    "title": "News for Sasquatch at the base facility.",
+    "items": [
+        {
+            "id": "7",
+            "url": "https://github.com/influxdata/chronograf/releases/tag/1.9.4",
+            "title": "Chronograf 1.9.4",
+            "content_text": "Upgrade Chronograf to the latest release.",
+            "date_published": "2022-04-07T02:00:00-07:00",
+            "date_modified": "2022-04-07T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+         {
+            "id": "6",
+            "url": "https://github.com/influxdata/chronograf/releases/tag/1.9.3",
+            "title": "Chronograf 1.9.3",
+            "content_text": "Upgrade Chronograf to the latest release.",
+            "date_published": "2022-01-27T02:00:00-07:00",
+            "date_modified": "2022-01-27T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "5",
+            "url": "https://github.com/influxdata/chronograf/releases/tag/1.9.1",
+            "title": "Chronograf 1.9.1",
+            "content_text": "This version fixes three issues in Chronograf reported by us (yay!) #5784: Fix Safari display issues of a Single Stat, #5796: Avoid useless browser history change, and #5803: Repair time rendering in horizontal table.",
+            "date_published": "2021-10-13T02:00:00-07:00",
+            "date_modified": "2021-10-13T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "4",
+            "url": "https://jira.lsstcorp.org/browse/DM-30083",
+            "title": "EFD time scale is now UTC",
+            "content_text": "According to RFC-767 we are switching the EFD time scale from TAI to UTC. This means that when you query the EFD via Chronograf or the EFD client the timestamps for the InfluxDB time column are returned in UTC. So you can use functions like now() in your InfluxQL queries safely, and manipulate time using Flux without worring about the time shift between TAI and UTC. The column private_sndStamp still has the timestamp values in TAI in case you need to work with them.",
+            "date_published": "2021-08-19T02:00:01-07:00",
+            "date_modified": "2021-08-19T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "3",
+            "url": "https://github.com/influxdata/chronograf/issues/5782",
+            "title": "Chronograf display issues with Safari",
+            "content_text": "We have seen issues rendering Tables and Single Stat panels on dashboard cells with recent versions of Safari. We recommend using Chrome for a better experience. ",
+            "date_published": "2021-08-04T02:00:01-07:00",
+            "date_modified": "2021-08-04T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "2",
+            "url": "https://docs.influxdata.com/chronograf/v1.9/guides/create-a-dashboard/#configure-dashboard-wide-settings",
+            "title": "Custom auto-refresh intervals",
+            "content_text": "In Chronograf 1.9.0 we can now configure custom auto-refresh intervals for dashboards. We added the option to refresh dashboard contents every 1s. However, use this feature with caution if your dashboard has too many cells or if you are querying data on large time ranges.",
+            "date_published": "2021-08-04T02:00:01-07:00",
+            "date_modified": "2021-08-04T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "1",
+            "url": "https://www.influxdata.com/blog/release-announcement-chronograf-1-9-0/",
+            "title": "Chronograf upgraded to version 1.9.0",
+            "content_text": "Chronograf 1.9.0 brings a number of new features and improvements, see blog post linked above.",
+            "date_published": "2021-08-04T02:00:01-07:00",
+            "date_modified": "2021-08-04T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        }
+    ]
+}

--- a/jsonfeeds/idfdev.json
+++ b/jsonfeeds/idfdev.json
@@ -1,0 +1,23 @@
+{
+    "version": "https://jsonfeed.org/version/1.1",
+    "user_comment": "Sasquatch news feed.",
+    "home_page_url": "https://data-dev.lsst.cloud/chronograf/",
+    "feed_url": "https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/idfdev.json",
+    "title": "News for Sasquatch at the IDF development cluster.",
+    "items": [
+        {
+            "id": "12",
+            "url": "https://sqr-068.lsst.io",
+            "title": "Long live Sasquatch!",
+            "content_text": "Sasquatch is a new service of the RSP that hosts the EFD, learn more at SQR-068.",
+            "date_published": "2022-07-11T02:00:00-07:00",
+            "date_modified": "2022-07-11T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        }
+    ]
+}

--- a/jsonfeeds/summit.json
+++ b/jsonfeeds/summit.json
@@ -1,0 +1,107 @@
+{
+    "version": "https://jsonfeed.org/version/1.1",
+    "user_comment": "Sasquatch news feed.",
+    "home_page_url": "https://chronograf-summit-efd.lsst.codes",
+    "feed_url": "https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/summit.json",
+    "title": "News for Sasquatch at the Summit.",
+    "items": [
+        {
+            "id": "7",
+            "url": "https://github.com/influxdata/chronograf/releases/tag/1.9.4",
+            "title": "Chronograf 1.9.4",
+            "content_text": "Upgrade Chronograf to the latest release.",
+            "date_published": "2022-04-07T02:00:00-07:00",
+            "date_modified": "2022-04-07T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "6",
+            "url": "https://github.com/influxdata/chronograf/releases/tag/1.9.3",
+            "title": "Chronograf 1.9.3",
+            "content_text": "Upgrade Chronograf to the latest release.",
+            "date_published": "2022-01-27T02:00:00-07:00",
+            "date_modified": "2022-01-27T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "5",
+            "url": "https://jira.lsstcorp.org/browse/DM-30083",
+            "title": "EFD time scale is now UTC",
+            "content_text": "According to RFC-767 we are switching the EFD time scale from TAI to UTC. This means that when you query the EFD via Chronograf or the EFD client the timestamps for the InfluxDB time column are returned in UTC. So you can use functions like now() in your InfluxQL queries safely, and manipulate time using Flux without worring about the time shift between TAI and UTC. The column private_sndStamp still has the timestamp values in TAI in case you need to work with them. This change affects telemetry recorded after 2021-10-13 21:46:57 UTC at the Summit EFD.",
+            "date_published": "2021-10-13T03:00:01-07:00",
+            "date_modified": "2021-10-13T03:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "4",
+            "url": "https://github.com/influxdata/chronograf/releases/tag/1.9.1",
+            "title": "Chronograf 1.9.1",
+            "content_text": "This version fixes three issues in Chronograf reported by us (yay!) #5784: Fix Safari display issues of a Single Stat, #5796: Avoid useless browser history change, and #5803: Repair time rendering in horizontal table.",
+            "date_published": "2021-10-13T02:00:00-07:00",
+            "date_modified": "2021-10-13T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "3",
+            "url": "https://github.com/influxdata/chronograf/issues/5782",
+            "title": "Chronograf display issues with Safari",
+            "content_text": "We have seen issues rendering Tables and Single Stat panels on dashboard cells with recent versions of Safari. We recommend using Chrome for a better experience. ",
+            "date_published": "2021-08-04T02:00:01-07:00",
+            "date_modified": "2021-08-04T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "2",
+            "url": "https://docs.influxdata.com/chronograf/v1.9/guides/create-a-dashboard/#configure-dashboard-wide-settings",
+            "title": "Custom auto-refresh intervals",
+            "content_text": "In Chronograf 1.9.0 we can now configure custom auto-refresh intervals for dashboards. We added the option to refresh dashboard contents every 1s. However, use this feature with caution if your dashboard has too many cells or if you are querying data on large time ranges.",
+            "date_published": "2021-08-04T02:00:01-07:00",
+            "date_modified": "2021-08-04T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "1",
+            "url": "https://www.influxdata.com/blog/release-announcement-chronograf-1-9-0/",
+            "title": "Chronograf 1.9.0",
+            "content_text": "Chronograf 1.9.0 brings a number of new features and improvements, see blog post linked above for more information.",
+            "date_published": "2021-08-04T02:00:01-07:00",
+            "date_modified": "2021-08-04T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        }
+    ]
+}

--- a/jsonfeeds/tucson-teststand.json
+++ b/jsonfeeds/tucson-teststand.json
@@ -1,0 +1,175 @@
+{
+    "version": "https://jsonfeed.org/version/1.1",
+    "user_comment": "Sasquatch news feed.",
+    "home_page_url": "https://tucson-teststand.lsst.codes/chronograf",
+    "feed_url": "https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/tucson-teststand.json",
+    "title": "News for Sasquatch at the Tucson Teststand.",
+    "items": [
+        {
+            "id": "12",
+            "url": "https://sqr-068.lsst.io",
+            "title": "Long live Sasquatch!",
+            "content_text": "Sasquatch is a new service of the RSP that hosts the EFD, learn more at SQR-068.",
+            "date_published": "2022-07-11T02:00:00-07:00",
+            "date_modified": "2022-07-11T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "11",
+            "url": "https://jira.lsstcorp.org/browse/DM-34040",
+            "title": "Increase InfluxDB time precision",
+            "content_text": "Some CSCs send events to the EFD with a time difference smaller than 1ms. We have increasead the time precision in InfluxDB from milliseconds to microseconds to account for that.",
+            "date_published": "2022-05-09T02:00:00-07:00",
+            "date_modified": "2022-05-09T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },{
+            "id": "10",
+            "url": "https://github.com/influxdata/chronograf/releases/tag/1.9.4",
+            "title": "Chronograf 1.9.4",
+            "content_text": "Upgrade Chronograf to the latest release.",
+            "date_published": "2022-04-07T02:00:00-07:00",
+            "date_modified": "2022-04-07T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },{
+            "id": "9",
+            "url": "https://github.com/influxdata/chronograf/releases/tag/1.9.3",
+            "title": "Chronograf 1.9.3",
+            "content_text": "Upgrade Chronograf to the latest release.",
+            "date_published": "2022-01-27T02:00:00-07:00",
+            "date_modified": "2022-01-27T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "8",
+            "url": "https://github.com/influxdata/chronograf/blob/master/CHANGELOG.md",
+            "title": "Chronograf 1.9.2 (nightly build)",
+            "content_text": "We've updated Chronograf to a nightly build that includes a fix to issue #5836: Allow to save a new TICKscript, reported by Michael. This will be rolled out elsewhere when 1.9.2 is released.",
+            "date_published": "2022-01-20T03:00:00-07:00",
+            "date_modified": "2022-01-20T03:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "7",
+            "url": "https://github.com/influxdata/chronograf/releases/tag/1.9.1",
+            "title": "Chronograf 1.9.1",
+            "content_text": "This version fixes three issues in Chronograf reported by us (yay!) #5784: Fix Safari display issues of a Single Stat, #5796: Avoid useless browser history change, and #5803: Repair time rendering in horizontal table.",
+            "date_published": "2021-10-13T02:00:00-07:00",
+            "date_modified": "2021-10-13T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "6",
+            "url": "https://chronograf-tucson-teststand-efd.lsst.codes",
+            "title": "Tucson Test Stand EFD",
+            "content_text": "We have a new EFD deployment at the Tucson Test Stand ready to use! It has essentially the same configuration used in the EFD at the NCSA Test Stand.",
+            "date_published": "2021-09-09T02:00:00-07:00",
+            "date_modified": "2021-09-09T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "5",
+            "url": "https://jira.lsstcorp.org/browse/DM-30083",
+            "title": "EFD time scale is now UTC",
+            "content_text": "According to RFC-767 we are switching the EFD time scale from TAI to UTC. This means that when you query the EFD via Chronograf or the EFD client the timestamps for the InfluxDB time column are returned in UTC. So you can use functions like now() in your InfluxQL queries safely, and manipulate time using Flux without worring about the time shift between TAI and UTC. The column private_sndStamp still has the timestamp values in TAI in case you need to work with them.",
+            "date_published": "2021-08-19T02:00:01-07:00",
+            "date_modified": "2021-08-19T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "4",
+            "url": "https://jira.lsstcorp.org/browse/DM-30083",
+            "title": "EFD time scale is now UTC",
+            "content_text": "According to RFC-767 we are switching the EFD time scale from TAI to UTC. This means that when you query the EFD via Chronograf or the EFD client the timestamps for the InfluxDB time column are returned in UTC. So you can use functions like now() in your InfluxQL queries safely, and manipulate time using Flux without worring about the time shift between TAI and UTC. The column private_sndStamp still has the timestamp values in TAI in case you need to work with them.",
+            "date_published": "2021-08-19T02:00:01-07:00",
+            "date_modified": "2021-08-19T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "3",
+            "url": "https://github.com/influxdata/chronograf/issues/5782",
+            "title": "Chronograf display issues with Safari",
+            "content_text": "We have seen issues rendering Tables and Single Stat panels on dashboard cells with recent versions of Safari. We recommend using Chrome for a better experience. ",
+            "date_published": "2021-08-04T02:00:01-07:00",
+            "date_modified": "2021-08-04T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "2",
+            "url": "https://docs.influxdata.com/chronograf/v1.9/guides/create-a-dashboard/#configure-dashboard-wide-settings",
+            "title": "Custom auto-refresh intervals",
+            "content_text": "In Chronograf 1.9.0 we can now configure custom auto-refresh intervals for dashboards. We added the option to refresh dashboard contents every 1s. However, use this feature with caution if your dashboard has too many cells or if you are querying data on large time ranges.",
+            "date_published": "2021-08-04T02:00:01-07:00",
+            "date_modified": "2021-08-04T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        },
+        {
+            "id": "1",
+            "url": "https://www.influxdata.com/blog/release-announcement-chronograf-1-9-0/",
+            "title": "Chronograf upgraded to version 1.9.0",
+            "content_text": "Chronograf 1.9.0 brings a number of new features and improvements, see blog post linked above.",
+            "date_published": "2021-08-04T02:00:01-07:00",
+            "date_modified": "2021-08-04T02:00:01-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Add JSON feed files used to display the news feed on the Chronograf status page.

The result can be seen on https://data-dev.lsst.cloud/chronograf/ I have a ticket branch in Phalanx pointing to https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/tickets/DM-35575/jsonfeeds/idfdev.json for the moment.