### PR TITLE
Update IDF status feed

### DIFF
--- a/jsonfeeds/idfdint.json
+++ b/jsonfeeds/idfdint.json
@@ -1,0 +1,23 @@
+{
+    "version": "https://jsonfeed.org/version/1.1",
+    "user_comment": "Sasquatch news feed.",
+    "home_page_url": "https://data-int.lsst.cloud/chronograf/",
+    "feed_url": "https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/idfint.json",
+    "title": "News for Sasquatch at the IDF integration cluster.",
+    "items": [
+        {
+            "id": "1",
+            "url": "https://sasquatch.lsst.io/environments.html",
+            "title": "New IDF EFD environment.",
+            "content_text": "The IDF environment is a short-term solution to serve historical EFD data until we can restore data at USDF.",
+            "date_published": "2023-10-24T02:00:00-07:00",
+            "date_modified": "2023-10-24T02:00:00-07:00",
+            "image": "",
+            "authors": [
+                {
+                    "name": "SQuaRE"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Add news about the IDF environment, a short-term solution to serve historical EFD data until we can restore data at USDF.